### PR TITLE
feat: improve appeal header metadata

### DIFF
--- a/components/Appeals/AppealHeader.tsx
+++ b/components/Appeals/AppealHeader.tsx
@@ -1,18 +1,39 @@
 // V:\lp\components\Appeals\AppealHeader.tsx
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import dayjs from 'dayjs';
 import { AppealDetail } from '@/types/appealsTypes';
 
 type Props = {
   data: AppealDetail;
+  title?: string;
   onChangeStatus?: () => void;
   onAssign?: () => void;
   onWatch?: () => void;
 };
 
-export default function AppealHeader({ data, onChangeStatus, onAssign, onWatch }: Props) {
+export default function AppealHeader({
+  data,
+  title = data.title || 'Без названия',
+  onChangeStatus,
+  onAssign,
+  onWatch,
+}: Props) {
+  const fromDept = data.fromDepartment?.name ?? '—';
+  const toDept = data.toDepartment.name;
+  const createdAt = dayjs(data.createdAt).format('DD.MM.YY HH:mm');
+  const formattedDeadline = data.deadline ? dayjs(data.deadline).format('DD.MM.YY HH:mm') : null;
+  const isOverdue = formattedDeadline ? dayjs().isAfter(dayjs(data.deadline)) : false;
   return (
     <View style={styles.container}>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.departments}>{fromDept} → {toDept}</Text>
+      <View style={styles.datesRow}>
+        <Text style={styles.date}>{createdAt}</Text>
+        {formattedDeadline ? (
+          <Text style={[styles.date, isOverdue && styles.deadlineOverdue]}>→ {formattedDeadline}</Text>
+        ) : null}
+      </View>
       <View style={styles.row}>
         <Text style={styles.number}>#{data.number}</Text>
         <View style={[styles.badge, { backgroundColor: statusColor(data.status) }]}>
@@ -22,7 +43,6 @@ export default function AppealHeader({ data, onChangeStatus, onAssign, onWatch }
           <Text style={styles.badgeText}>{data.priority}</Text>
         </View>
       </View>
-      {data.title ? <Text style={styles.title}>{data.title}</Text> : null}
       <View style={styles.actions}>
         <TouchableOpacity style={styles.actionBtn} onPress={onChangeStatus}>
           <Text style={styles.actionText}>Статус</Text>
@@ -60,11 +80,15 @@ function priorityColor(priority: string) {
 
 const styles = StyleSheet.create({
   container: { padding: 16, borderBottomWidth: 1, borderColor: '#eee', backgroundColor: '#fff' },
+  title: { fontSize: 20, fontWeight: 'bold', marginBottom: 4, color: '#333' },
+  departments: { fontSize: 14, color: '#666', marginBottom: 4 },
+  datesRow: { flexDirection: 'row', marginBottom: 8 },
+  date: { fontSize: 12, color: '#666', marginRight: 8 },
+  deadlineOverdue: { color: '#F44336' },
   row: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
   number: { fontSize: 18, fontWeight: 'bold', marginRight: 8 },
   badge: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: 8, marginRight: 6 },
   badgeText: { color: '#fff', fontSize: 12 },
-  title: { fontSize: 16, marginBottom: 8, color: '#333' },
   actions: { flexDirection: 'row' },
   actionBtn: { marginRight: 12 },
   actionText: { color: '#007AFF', fontSize: 14 },


### PR DESCRIPTION
## Summary
- show appeal title prominently above header details
- display departments and formatted dates with overdue deadline color

## Testing
- `npm test` *(fails: Missing script)*
- `npx eslint components/Appeals/AppealHeader.tsx`
- `npx tsc --noEmit` *(fails: Cannot find name 'RelativePathString', Module ... not exported, Property 'hovered' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68af1f7163588324b1ac857a7834e9d7