### PR TITLE
feat: redesign appeal header with actions and deadline progress

### DIFF
--- a/app/(main)/services/appeals/[id].tsx
+++ b/app/(main)/services/appeals/[id].tsx
@@ -12,13 +12,11 @@ import {
 import { AppealDetail, AppealStatus } from '@/types/appealsTypes';
 import MessageBubble from '@/components/Appeals/MessageBubble';
 import AppealHeader from '@/components/Appeals/AppealHeader'; // <-- исправлено имя файла
-import AppealStatusMenu from '@/components/Appeals/AppealStatusMenu';
 
 export default function AppealDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const appealId = Number(id);
   const [data, setData] = useState<AppealDetail | null>(null);
-  const [statusMenu, setStatusMenu] = useState(false);
 
   const load = useCallback(async (force = false) => {
     const d = await getAppealById(appealId, force);
@@ -30,19 +28,14 @@ export default function AppealDetailScreen() {
   if (!data) return null;
 
   async function handleChangeStatus(next: AppealStatus) {
-    if (!data || next === data.status) { 
-      setStatusMenu(false); 
-      return; 
-    }
+    if (!data || next === data.status) return;
     try {
-      setData(prev => prev ? { ...prev, status: next } : prev); // ✅
+      setData(prev => (prev ? { ...prev, status: next } : prev));
       await updateAppealStatus(appealId, next);
       await load(true);
     } catch (e) {
       await load(true);
       console.warn('Ошибка смены статуса:', e);
-    } finally {
-      setStatusMenu(false);
     }
   }
 
@@ -50,7 +43,7 @@ export default function AppealDetailScreen() {
     <View style={{ flex: 1 }}>
       <AppealHeader
         data={data}
-        onChangeStatus={() => setStatusMenu(true)}
+        onChangeStatus={(s) => handleChangeStatus(s)}
         onAssign={() => assignAppeal(appealId, []).then(() => load(true))}
         onWatch={() => updateAppealWatchers(appealId, []).then(() => load(true))}
       />
@@ -64,13 +57,6 @@ export default function AppealDetailScreen() {
           />
         ))}
       </ScrollView>
-
-      <AppealStatusMenu
-        visible={statusMenu}
-        current={data.status}
-        onClose={() => setStatusMenu(false)}
-        onSelect={(s) => handleChangeStatus(s)}
-      />
 
       {/* input + attachments:
           onSend = async (text, files) => { await addAppealMessage(appealId, { text, files }); await load(true); }

--- a/components/Appeals/AppealHeader.tsx
+++ b/components/Appeals/AppealHeader.tsx
@@ -1,95 +1,296 @@
-// V:\lp\components\Appeals\AppealHeader.tsx
-import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { View, Text, StyleSheet, Animated, Pressable } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import AnimatedRe, { FadeInDown } from 'react-native-reanimated';
 import dayjs from 'dayjs';
-import { AppealDetail } from '@/types/appealsTypes';
+import { Ionicons } from '@expo/vector-icons';
+import Dropdown, { DropdownItem } from '@/components/ui/Dropdown';
+import AppealStatusMenu from './AppealStatusMenu';
+import { AppealDetail, AppealStatus, AppealPriority } from '@/types/appealsTypes';
 
 type Props = {
   data: AppealDetail;
   title?: string;
-  onChangeStatus?: () => void;
+  onChangeStatus?: (s: AppealStatus) => void;
   onAssign?: () => void;
   onWatch?: () => void;
 };
 
+const statusLabels: Record<AppealStatus, string> = {
+  OPEN: 'Открыто',
+  IN_PROGRESS: 'В работе',
+  RESOLVED: 'Решено',
+  CLOSED: 'Закрыто',
+};
+
+const priorityLabels: Record<AppealPriority, string> = {
+  LOW: 'Низкий',
+  MEDIUM: 'Средний',
+  HIGH: 'Высокий',
+  CRITICAL: 'Критический',
+};
+
+const PressableScale: React.FC<{ onPress?: () => void; style?: any; pressedStyle?: any; children: React.ReactNode }> = ({
+  onPress,
+  style,
+  pressedStyle,
+  children,
+}) => {
+  const scale = useRef(new Animated.Value(1)).current;
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() =>
+        Animated.timing(scale, { toValue: 0.96, duration: 80, useNativeDriver: true }).start()
+      }
+      onPressOut={() =>
+        Animated.timing(scale, { toValue: 1, duration: 110, useNativeDriver: true }).start()
+      }
+    >
+      {({ pressed }) => (
+        <Animated.View style={[style, pressed && pressedStyle, { transform: [{ scale }] }]}>
+          {children}
+        </Animated.View>
+      )}
+    </Pressable>
+  );
+};
+
 export default function AppealHeader({
   data,
-  title = data.title || 'Без названия',
+  title,
   onChangeStatus,
   onAssign,
   onWatch,
 }: Props) {
+  const displayTitle = title ?? data.title ?? data.messages[0]?.text ?? 'Без названия';
   const fromDept = data.fromDepartment?.name ?? '—';
   const toDept = data.toDepartment.name;
   const createdAt = dayjs(data.createdAt).format('DD.MM.YY HH:mm');
-  const formattedDeadline = data.deadline ? dayjs(data.deadline).format('DD.MM.YY HH:mm') : null;
-  const isOverdue = formattedDeadline ? dayjs().isAfter(dayjs(data.deadline)) : false;
+  const formattedDeadline = data.deadline
+    ? dayjs(data.deadline).format('DD.MM.YY HH:mm')
+    : null;
+
+  const progress = useMemo(() => {
+    if (!data.deadline) return null;
+    const start = dayjs(data.createdAt);
+    const end = dayjs(data.deadline);
+    const total = end.diff(start);
+    if (total <= 0) return 1;
+    const current = dayjs().diff(start);
+    return Math.min(current / total, 1);
+  }, [data.createdAt, data.deadline]);
+
+  const isOverdue = progress !== null && progress >= 1;
+
+  const progressAnim = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    if (progress !== null) {
+      Animated.timing(progressAnim, {
+        toValue: progress,
+        duration: 500,
+        useNativeDriver: false,
+      }).start();
+    }
+  }, [progress]);
+
+  const [statusMenuVisible, setStatusMenuVisible] = useState(false);
+
+  const actionItems: DropdownItem<'status' | 'assign' | 'watch'>[] = [
+    { label: 'Изменить статус', value: 'status' },
+    { label: 'Назначить', value: 'assign' },
+    { label: 'Наблюдать', value: 'watch' },
+  ];
+
+  const handleAction = (action: 'status' | 'assign' | 'watch') => {
+    switch (action) {
+      case 'status':
+        setStatusMenuVisible(true);
+        break;
+      case 'assign':
+        onAssign?.();
+        break;
+      case 'watch':
+        onWatch?.();
+        break;
+    }
+  };
+
+  const handleSelectStatus = (s: AppealStatus) => {
+    setStatusMenuVisible(false);
+    onChangeStatus?.(s);
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{title}</Text>
-      <Text style={styles.departments}>{fromDept} → {toDept}</Text>
-      <View style={styles.datesRow}>
-        <Text style={styles.date}>{createdAt}</Text>
-        {formattedDeadline ? (
-          <Text style={[styles.date, isOverdue && styles.deadlineOverdue]}>→ {formattedDeadline}</Text>
-        ) : null}
-      </View>
-      <View style={styles.row}>
-        <Text style={styles.number}>#{data.number}</Text>
-        <View style={[styles.badge, { backgroundColor: statusColor(data.status) }]}>
-          <Text style={styles.badgeText}>{data.status}</Text>
+    <AnimatedRe.View entering={FadeInDown.duration(250)} style={styles.wrapper}>
+      <LinearGradient
+        colors={['#0EA5E9', '#7C3AED']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.card}
+      >
+        <Dropdown
+          items={actionItems}
+          onChange={handleAction}
+          placeholder=""
+          style={styles.menuWrap}
+          buttonStyle={styles.iconBtn}
+          renderTrigger={() => (
+            <Ionicons name="ellipsis-horizontal" size={18} color="#fff" />
+          )}
+        />
+
+        <View style={styles.headerTextBlock}>
+          <Text style={styles.title}>{displayTitle}</Text>
+          <View style={styles.deptRow}>
+            <PressableScale style={styles.deptChip} pressedStyle={styles.deptChipPressed}>
+              <Text style={styles.deptText}>{fromDept}</Text>
+            </PressableScale>
+            <Ionicons name="chevron-forward" size={14} color="#fff" style={{ marginHorizontal: 4 }} />
+            <PressableScale style={styles.deptChip} pressedStyle={styles.deptChipPressed}>
+              <Text style={styles.deptText}>{toDept}</Text>
+            </PressableScale>
+          </View>
         </View>
-        <View style={[styles.badge, { backgroundColor: priorityColor(data.priority) }]}>
-          <Text style={styles.badgeText}>{data.priority}</Text>
+
+        {progress !== null && (
+          <View style={styles.deadlineWrap}>
+            <View style={styles.progressContainer}>
+              <Animated.View
+                style={[
+                  styles.progressBar,
+                  {
+                    width: progressAnim.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: ['0%', '100%'],
+                    }),
+                    backgroundColor: isOverdue ? '#F43F5E' : '#fff',
+                  },
+                ]}
+              />
+            </View>
+            <View style={styles.deadlineDates}>
+              <Text style={styles.date}>{createdAt}</Text>
+              {formattedDeadline && (
+                <Text style={[styles.date, isOverdue && styles.deadlineOverdue]}>
+                  {formattedDeadline}
+                </Text>
+              )}
+            </View>
+          </View>
+        )}
+
+        <View style={styles.infoRow}>
+          <Text style={styles.number}>#{data.number}</Text>
+          <View style={[styles.badge, { backgroundColor: statusColor(data.status) }]}>
+            <Text style={styles.badgeText}>{statusLabels[data.status]}</Text>
+          </View>
+          <View style={[styles.badge, { backgroundColor: priorityColor(data.priority) }]}>
+            <Text style={styles.badgeText}>{priorityLabels[data.priority]}</Text>
+          </View>
         </View>
-      </View>
-      <View style={styles.actions}>
-        <TouchableOpacity style={styles.actionBtn} onPress={onChangeStatus}>
-          <Text style={styles.actionText}>Статус</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.actionBtn} onPress={onAssign}>
-          <Text style={styles.actionText}>Назначить</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.actionBtn} onPress={onWatch}>
-          <Text style={styles.actionText}>Наблюдать</Text>
-        </TouchableOpacity>
-      </View>
-    </View>
+      </LinearGradient>
+
+      <AppealStatusMenu
+        visible={statusMenuVisible}
+        current={data.status}
+        onSelect={handleSelectStatus}
+        onClose={() => setStatusMenuVisible(false)}
+      />
+    </AnimatedRe.View>
   );
 }
 
-function statusColor(status: string) {
+function statusColor(status: AppealStatus) {
   switch (status) {
-    case 'OPEN': return '#4CAF50';
-    case 'IN_PROGRESS': return '#2196F3';
-    case 'RESOLVED': return '#9C27B0';
-    case 'CLOSED': return '#9E9E9E';
-    default: return '#607D8B';
+    case 'OPEN':
+      return '#4CAF50';
+    case 'IN_PROGRESS':
+      return '#2196F3';
+    case 'RESOLVED':
+      return '#9C27B0';
+    case 'CLOSED':
+      return '#9E9E9E';
+    default:
+      return '#607D8B';
   }
 }
 
-function priorityColor(priority: string) {
+function priorityColor(priority: AppealPriority) {
   switch (priority) {
-    case 'LOW': return '#8BC34A';
-    case 'MEDIUM': return '#FFC107';
-    case 'HIGH': return '#FF5722';
-    case 'CRITICAL': return '#F44336';
-    default: return '#9E9E9E';
+    case 'LOW':
+      return '#8BC34A';
+    case 'MEDIUM':
+      return '#FFC107';
+    case 'HIGH':
+      return '#FF5722';
+    case 'CRITICAL':
+      return '#F44336';
+    default:
+      return '#9E9E9E';
   }
 }
 
 const styles = StyleSheet.create({
-  container: { padding: 16, borderBottomWidth: 1, borderColor: '#eee', backgroundColor: '#fff' },
-  title: { fontSize: 20, fontWeight: 'bold', marginBottom: 4, color: '#333' },
-  departments: { fontSize: 14, color: '#666', marginBottom: 4 },
-  datesRow: { flexDirection: 'row', marginBottom: 8 },
-  date: { fontSize: 12, color: '#666', marginRight: 8 },
-  deadlineOverdue: { color: '#F44336' },
-  row: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
-  number: { fontSize: 18, fontWeight: 'bold', marginRight: 8 },
+  wrapper: { marginBottom: 16, marginHorizontal: 16 },
+  card: {
+    borderRadius: 20,
+    padding: 16,
+    paddingTop: 20,
+    overflow: 'hidden',
+    position: 'relative',
+    shadowColor: '#7C3AED',
+    shadowOpacity: 0.22,
+    shadowRadius: 14,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 5,
+  },
+  menuWrap: { position: 'absolute', top: 10, right: 10, zIndex: 2 },
+  iconBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.15)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.75)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 0,
+    paddingVertical: 0,
+  },
+  headerTextBlock: { marginBottom: 12, paddingRight: 56 },
+  title: { color: '#fff', fontWeight: '800', fontSize: 20, letterSpacing: 0.2 },
+  deptRow: { flexDirection: 'row', alignItems: 'center', marginTop: 4 },
+  deptChip: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+    backgroundColor: 'rgba(255,255,255,0.15)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.75)',
+  },
+  deptChipPressed: { backgroundColor: 'rgba(255,255,255,0.25)' },
+  deptText: { color: '#fff', fontSize: 12, fontWeight: '600' },
+  deadlineWrap: { marginBottom: 12 },
+  progressContainer: {
+    height: 6,
+    backgroundColor: 'rgba(255,255,255,0.25)',
+    borderRadius: 999,
+    overflow: 'hidden',
+  },
+  progressBar: { height: '100%' },
+  deadlineDates: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 4,
+  },
+  date: { fontSize: 12, color: 'rgba(255,255,255,0.95)' },
+  deadlineOverdue: { color: '#F43F5E' },
+  infoRow: { flexDirection: 'row', alignItems: 'center', marginTop: 8 },
+  number: { fontSize: 18, fontWeight: 'bold', color: '#fff', marginRight: 8 },
   badge: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: 8, marginRight: 6 },
-  badgeText: { color: '#fff', fontSize: 12 },
-  actions: { flexDirection: 'row' },
-  actionBtn: { marginRight: 12 },
-  actionText: { color: '#007AFF', fontSize: 14 },
+  badgeText: { color: '#fff', fontSize: 12, fontWeight: '600' },
 });
+
+export {};
+


### PR DESCRIPTION
## Summary
- add spacing, clickable department chips, and date-labeled deadline bar to appeal header
- restyle header action menu with animated ellipsis trigger
- animate dropdown trigger and clamp menu to viewport edges

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find name 'RelativePathString', missing exports and other errors)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af262c2144832496081aa7ad31e7ba