### PR TITLE
feat(chat): add voice messages and UI tweaks

### DIFF
--- a/app/(main)/services/appeals/[id].tsx
+++ b/app/(main)/services/appeals/[id].tsx
@@ -1,7 +1,7 @@
 // V:\lp\app\(main)\services\appeals\[id].tsx
 import { useLocalSearchParams } from 'expo-router';
-import { useEffect, useState, useCallback } from 'react';
-import { View, ScrollView } from 'react-native';
+import { useEffect, useState, useCallback, useContext } from 'react';
+import { View } from 'react-native';
 import {
   addAppealMessage,
   getAppealById,
@@ -10,13 +10,16 @@ import {
   updateAppealWatchers,
 } from '@/utils/appealsService';
 import { AppealDetail, AppealStatus } from '@/types/appealsTypes';
-import MessageBubble from '@/components/Appeals/MessageBubble';
 import AppealHeader from '@/components/Appeals/AppealHeader'; // <-- исправлено имя файла
+import MessagesList from '@/components/Appeals/MessagesList';
+import AppealChatInput from '@/components/Appeals/AppealChatInput';
+import { AuthContext } from '@/context/AuthContext';
 
 export default function AppealDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const appealId = Number(id);
   const [data, setData] = useState<AppealDetail | null>(null);
+  const auth = useContext(AuthContext);
 
   const load = useCallback(async (force = false) => {
     const d = await getAppealById(appealId, force);
@@ -48,19 +51,14 @@ export default function AppealDetailScreen() {
         onWatch={() => updateAppealWatchers(appealId, []).then(() => load(true))}
       />
 
-      <ScrollView style={{ flex: 1 }}>
-        {data.messages.map(m => (
-          <MessageBubble
-            key={m.id}
-            message={m}
-            own={false /* сравни с текущим userId */}
-          />
-        ))}
-      </ScrollView>
+      <MessagesList messages={data.messages || []} currentUserId={auth?.profile?.id} />
 
-      {/* input + attachments:
-          onSend = async (text, files) => { await addAppealMessage(appealId, { text, files }); await load(true); }
-      */}
+      <AppealChatInput
+        onSend={async ({ text, files }) => {
+          await addAppealMessage(appealId, { text, files });
+          await load(true);
+        }}
+      />
     </View>
   );
 }

--- a/components/Appeals/AppealChatInput.tsx
+++ b/components/Appeals/AppealChatInput.tsx
@@ -1,0 +1,312 @@
+// components/Appeals/AppealChatInput.tsx
+import React, { useState, useRef, useEffect } from 'react';
+import { View, TextInput, Pressable, StyleSheet, Text, Animated } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as DocumentPicker from 'expo-document-picker';
+import { Audio } from 'expo-av';
+import { MotiView } from 'moti';
+import { AttachmentFile } from '@/components/ui/AttachmentsPicker';
+
+export default function AppealChatInput({
+  onSend,
+}: {
+  onSend: (payload: { text?: string; files?: AttachmentFile[] }) => Promise<void> | void;
+}) {
+  const [text, setText] = useState('');
+  const [files, setFiles] = useState<AttachmentFile[]>([]);
+  const [sending, setSending] = useState(false);
+  const [recording, setRecording] = useState<Audio.Recording | null>(null);
+  const [recordedUri, setRecordedUri] = useState<string | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordingTime, setRecordingTime] = useState(0);
+
+  const attachScale = useRef(new Animated.Value(1)).current;
+  const sendScale = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+    if (isRecording) {
+      timer = setInterval(() => setRecordingTime((t) => t + 1), 1000);
+    }
+    return () => {
+      if (timer) clearInterval(timer);
+    };
+  }, [isRecording]);
+
+  function animateIn(val: Animated.Value) {
+    Animated.spring(val, { toValue: 0.9, useNativeDriver: true }).start();
+  }
+
+  function animateOut(val: Animated.Value) {
+    Animated.spring(val, { toValue: 1, useNativeDriver: true }).start();
+  }
+
+  function formatTime(sec: number) {
+    const m = Math.floor(sec / 60)
+      .toString()
+      .padStart(2, '0');
+    const s = (sec % 60).toString().padStart(2, '0');
+    return `${m}:${s}`;
+  }
+
+  async function startRecording() {
+    try {
+      const perm = await Audio.requestPermissionsAsync();
+      if (!perm.granted) return;
+      await Audio.setAudioModeAsync({ allowsRecordingIOS: true, playsInSilentModeIOS: true });
+      const rec = new Audio.Recording();
+      await rec.prepareToRecordAsync(Audio.RecordingOptionsPresets.HIGH_QUALITY);
+      await rec.startAsync();
+      setRecording(rec);
+      setIsRecording(true);
+      setRecordingTime(0);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  async function stopRecording() {
+    try {
+      const rec = recording;
+      if (!rec) return;
+      await rec.stopAndUnloadAsync();
+      const uri = rec.getURI();
+      setRecordedUri(uri || null);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setIsRecording(false);
+      setRecording(null);
+    }
+  }
+
+  function cancelVoice() {
+    setRecordedUri(null);
+    setRecordingTime(0);
+  }
+
+  async function pickFiles() {
+    try {
+      const res = await DocumentPicker.getDocumentAsync({ multiple: true, copyToCacheDirectory: true });
+      const anyRes: any = res as any;
+      const canceled = anyRes.canceled === true || anyRes.type === 'cancel';
+      if (canceled) return;
+      const assets: any[] = anyRes.assets ?? (anyRes.type === 'success' || anyRes.uri ? [anyRes] : []);
+      if (!assets?.length) return;
+      const mapped: AttachmentFile[] = assets
+        .filter((a) => a && a.uri)
+        .map((a) => ({ uri: a.uri, name: a.name || 'file', type: a.mimeType || a.type || 'application/octet-stream' }));
+      setFiles((prev) => [...prev, ...mapped]);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  function removeFile(idx: number) {
+    setFiles((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  async function handleSend() {
+    if (sending || (!text.trim() && files.length === 0)) return;
+    setSending(true);
+    try {
+      await onSend({ text: text.trim() || undefined, files });
+      setText('');
+      setFiles([]);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  async function handleSendVoice() {
+    if (sending || !recordedUri) return;
+    setSending(true);
+    try {
+      const voice: AttachmentFile = {
+        uri: recordedUri,
+        name: 'voice-message.m4a',
+        type: 'audio/m4a',
+      };
+      await onSend({ files: [voice] });
+      cancelVoice();
+    } finally {
+      setSending(false);
+    }
+  }
+
+  const canSend = text.trim().length > 0 || files.length > 0;
+
+  return (
+    <View style={styles.wrapper}>
+      {files.length > 0 && (
+        <View style={styles.chipsWrap}>
+          {files.map((f, idx) => (
+            <View key={`${f.uri}-${idx}`} style={styles.fileChip}>
+              <Ionicons name="document" size={14} color="#2563EB" />
+              <Text style={styles.fileChipText} numberOfLines={1}>{f.name}</Text>
+              <Pressable onPress={() => removeFile(idx)} hitSlop={8}>
+                <Ionicons name="close" size={14} color="#6B7280" />
+              </Pressable>
+            </View>
+          ))}
+        </View>
+      )}
+      <View style={styles.inputRow}>
+        <Pressable
+          onPress={pickFiles}
+          style={styles.attachBtn}
+          hitSlop={8}
+          onPressIn={() => animateIn(attachScale)}
+          onPressOut={() => animateOut(attachScale)}
+          disabled={isRecording}
+        >
+          <Animated.View style={{ transform: [{ scale: attachScale }] }}>
+            <Ionicons name="attach" size={22} color="#2563EB" />
+          </Animated.View>
+        </Pressable>
+
+        {isRecording ? (
+          <View style={styles.recordingBox}>
+            <MotiView
+              style={styles.wave}
+              from={{ scaleY: 0.4 }}
+              animate={{ scaleY: 1 }}
+              transition={{ type: 'timing', duration: 500, loop: true }}
+            />
+            <Text style={styles.recordingTime}>{formatTime(recordingTime)}</Text>
+          </View>
+        ) : recordedUri ? (
+          <View style={styles.voicePreview}>
+            <Ionicons name="mic" size={20} color="#2563EB" />
+            <Text style={styles.recordingTime}>{formatTime(recordingTime)}</Text>
+            <Pressable onPress={cancelVoice} hitSlop={8} style={styles.cancelVoice}>
+              <Ionicons name="close" size={16} color="#6B7280" />
+            </Pressable>
+          </View>
+        ) : (
+          <TextInput
+            style={styles.input}
+            multiline
+            placeholder="Сообщение"
+            placeholderTextColor="#9CA3AF"
+            value={text}
+            onChangeText={setText}
+          />
+        )}
+
+        {recordedUri ? (
+          <Pressable
+            onPress={handleSendVoice}
+            disabled={sending}
+            onPressIn={() => animateIn(sendScale)}
+            onPressOut={() => animateOut(sendScale)}
+            style={[styles.sendBtn, sending && { opacity: 0.5 }]}
+            hitSlop={8}
+          >
+            <Animated.View style={{ transform: [{ scale: sendScale }] }}>
+              <Ionicons name="send" size={20} color="#fff" />
+            </Animated.View>
+          </Pressable>
+        ) : canSend ? (
+          <Pressable
+            onPress={handleSend}
+            disabled={sending}
+            onPressIn={() => animateIn(sendScale)}
+            onPressOut={() => animateOut(sendScale)}
+            style={[styles.sendBtn, (sending) && { opacity: 0.5 }]}
+            hitSlop={8}
+          >
+            <Animated.View style={{ transform: [{ scale: sendScale }] }}>
+              <Ionicons name="send" size={20} color="#fff" />
+            </Animated.View>
+          </Pressable>
+        ) : (
+          <Pressable
+            onLongPress={startRecording}
+            onPressIn={() => animateIn(sendScale)}
+            onPressOut={() => {
+              animateOut(sendScale);
+              if (isRecording) stopRecording();
+            }}
+            delayLongPress={200}
+            style={styles.micBtn}
+            hitSlop={8}
+          >
+            <Animated.View style={{ transform: [{ scale: sendScale }] }}>
+              <Ionicons name="mic" size={22} color="#2563EB" />
+            </Animated.View>
+          </Pressable>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: { padding: 8, backgroundColor: '#F9FAFB', borderTopWidth: 1, borderColor: '#E5E7EB' },
+  chipsWrap: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 8 },
+  fileChip: {
+    flexDirection: 'row', alignItems: 'center', gap: 6,
+    borderWidth: 1, borderColor: '#E5E7EB', backgroundColor: '#fff',
+    borderRadius: 999, paddingVertical: 6, paddingHorizontal: 10, maxWidth: '100%',
+  },
+  fileChipText: { maxWidth: 160, color: '#111827', fontSize: 12 },
+  inputRow: { flexDirection: 'row', alignItems: 'flex-end' },
+  attachBtn: { padding: 6, justifyContent: 'center' },
+  micBtn: { padding: 6, justifyContent: 'center' },
+  input: {
+    flex: 1,
+    maxHeight: 120,
+    minHeight: 40,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 20,
+    paddingHorizontal: 12,
+    paddingTop: 8,
+    paddingBottom: 8,
+    color: '#111827',
+    marginHorizontal: 8,
+  },
+  recordingBox: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginHorizontal: 8,
+  },
+  wave: {
+    width: 20,
+    height: 20,
+    marginRight: 8,
+    backgroundColor: '#2563EB',
+    borderRadius: 10,
+  },
+  recordingTime: { color: '#111827' },
+  voicePreview: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 20,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    marginHorizontal: 8,
+    position: 'relative',
+  },
+  cancelVoice: { position: 'absolute', right: 6, top: 6 },
+  sendBtn: {
+    backgroundColor: '#2563EB',
+    borderRadius: 20,
+    padding: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/components/Appeals/MessageBubble.tsx
+++ b/components/Appeals/MessageBubble.tsx
@@ -1,15 +1,111 @@
-import { View, Text, Image } from 'react-native';
+import { Text, Image, StyleSheet, View, Pressable } from 'react-native';
+import { useState } from 'react';
+import { Audio } from 'expo-av';
+import { Ionicons } from '@expo/vector-icons';
 import { AppealMessage } from '@/types/appealsTypes';
+import { MotiView } from 'moti';
 
 export default function MessageBubble({ message, own }: { message: AppealMessage; own: boolean }) {
+  const attachments = Array.isArray(message.attachments)
+    ? message.attachments.filter((a): a is NonNullable<typeof a> => !!a)
+    : [];
+
+  const dt = new Date(message.createdAt);
+  const timeStr = new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' }).format(dt);
+  const dateStr = new Intl.DateTimeFormat(undefined, { day: '2-digit', month: '2-digit', year: '2-digit' }).format(dt);
+
+  const [sound, setSound] = useState<Audio.Sound | null>(null);
+  const [playing, setPlaying] = useState(false);
+
+  async function playAudio(uri: string) {
+    try {
+      if (playing) {
+        await sound?.stopAsync();
+        setPlaying(false);
+        return;
+      }
+      const { sound: s } = await Audio.Sound.createAsync({ uri });
+      setSound(s);
+      setPlaying(true);
+      await s.playAsync();
+      s.setOnPlaybackStatusUpdate((status) => {
+        if (!('didJustFinish' in status)) return;
+        if (status.didJustFinish) {
+          setPlaying(false);
+          s.unloadAsync();
+        }
+      });
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   return (
-    <View style={{ alignSelf: own ? 'flex-end' : 'flex-start', maxWidth: '85%', padding: 10, margin: 8, backgroundColor: own ? '#DCF7C5' : '#F1F1F1', borderRadius: 10 }}>
-      {message.text ? <Text>{message.text}</Text> : null}
-      {message.attachments?.map((a) => (
-        a.fileType === 'IMAGE' ? <Image key={a.fileUrl} source={{ uri: a.fileUrl }} style={{ width: 200, height: 120, marginTop: 6 }} /> :
-        <Text key={a.fileUrl} style={{ marginTop: 6, textDecorationLine: 'underline' }}>{a.fileName}</Text>
-      ))}
-      <Text style={{ fontSize: 12, color: '#666', marginTop: 4 }}>{new Date(message.createdAt).toLocaleString()}</Text>
-    </View>
+    <MotiView
+      from={{ opacity: 0, translateY: 10 }}
+      animate={{ opacity: 1, translateY: 0 }}
+      style={[styles.bubble, own ? styles.own : styles.other]}
+    >
+      {message.text ? <Text style={styles.text}>{message.text}</Text> : null}
+      {attachments.map((a, idx) => {
+        if (a.fileType === 'IMAGE' && a.fileUrl) {
+          return <Image key={`${a.fileUrl}-${idx}`} source={{ uri: a.fileUrl }} style={styles.image} />;
+        }
+        if (a.fileType === 'AUDIO' && a.fileUrl) {
+          return (
+            <Pressable
+              key={`${a.fileUrl}-${idx}`}
+              style={styles.audio}
+              onPress={() => playAudio(a.fileUrl)}
+            >
+              <Ionicons name={playing ? 'pause' : 'play'} size={16} color="#2563EB" />
+              <Text style={styles.audioText}>{a.fileName || 'Voice message'}</Text>
+            </Pressable>
+          );
+        }
+        if (a.fileName) {
+          return (
+            <Text key={`${a.fileUrl || a.fileName}-${idx}`} style={styles.file}>
+              {a.fileName}
+            </Text>
+          );
+        }
+        return null;
+      })}
+      <View style={styles.meta}>
+        <Text style={styles.time}>{timeStr}</Text>
+        <Text style={styles.date}>{dateStr}</Text>
+      </View>
+    </MotiView>
   );
 }
+
+const styles = StyleSheet.create({
+  bubble: {
+    alignSelf: 'flex-start',
+    maxWidth: '85%',
+    padding: 10,
+    marginHorizontal: 8,
+    marginVertical: 4,
+    borderRadius: 10,
+  },
+  own: { alignSelf: 'flex-end', backgroundColor: '#DCF7C5' },
+  other: { backgroundColor: '#F1F1F1' },
+  text: { color: '#111827' },
+  image: { width: 200, height: 120, marginTop: 6, borderRadius: 8 },
+  file: { marginTop: 6, textDecorationLine: 'underline', color: '#2563EB' },
+  audio: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 6,
+  },
+  audioText: { color: '#2563EB', textDecorationLine: 'underline' },
+  meta: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 4,
+  },
+  time: { fontSize: 12, color: '#666' },
+  date: { fontSize: 12, color: '#666' },
+});

--- a/components/Appeals/MessagesList.tsx
+++ b/components/Appeals/MessagesList.tsx
@@ -1,0 +1,34 @@
+// components/Appeals/MessagesList.tsx
+import React, { useEffect, useRef } from 'react';
+import { FlatList, StyleSheet } from 'react-native';
+import { AppealMessage } from '@/types/appealsTypes';
+import MessageBubble from './MessageBubble';
+
+export default function MessagesList({
+  messages,
+  currentUserId,
+}: {
+  messages: AppealMessage[];
+  currentUserId?: number;
+}) {
+  const listRef = useRef<FlatList<AppealMessage>>(null);
+  useEffect(() => {
+    listRef.current?.scrollToEnd({ animated: true });
+  }, [messages]);
+
+  return (
+    <FlatList
+      ref={listRef}
+      data={messages}
+      keyExtractor={(item) => String(item.id)}
+      renderItem={({ item }) => (
+        <MessageBubble message={item} own={item.sender?.id === currentUserId} />
+      )}
+      contentContainerStyle={styles.container}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { paddingVertical: 8 },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
         "expo": "53.0.20",
+        "expo-av": "^15.1.7",
         "expo-blur": "~14.1.5",
         "expo-clipboard": "^7.1.5",
         "expo-constants": "~17.1.7",
@@ -7364,6 +7365,23 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-av": {
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-15.1.7.tgz",
+      "integrity": "sha512-NC+JR+65sxXfQN1mOHp3QBaXTL2J+BzNwVO27XgUEc5s9NaoBTdHWElYXrfxvik6xwytZ+a7abrqfNNgsbQzsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-blur": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "expo": "53.0.20",
+    "expo-av": "^15.1.7",
     "expo-blur": "~14.1.5",
     "expo-clipboard": "^7.1.5",
     "expo-constants": "~17.1.7",


### PR DESCRIPTION
## Summary
- format message timestamps into separate time and date fields
- animate chat input buttons and enable voice message recording/sending
- play audio attachments inside chat bubbles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint components/Appeals/AppealChatInput.tsx components/Appeals/MessageBubble.tsx app/(main)/services/appeals/[id].tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af396b5f8c83249ade690fcbd2c535