### PR TITLE
Reset audio mode after recording

### DIFF
--- a/components/Appeals/AppealChatInput.tsx
+++ b/components/Appeals/AppealChatInput.tsx
@@ -22,6 +22,7 @@ export default function AppealChatInput({
 
   const attachScale = useRef(new Animated.Value(1)).current;
   const sendScale = useRef(new Animated.Value(1)).current;
+  const recordingRef = useRef<Audio.Recording | null>(null);
 
   useEffect(() => {
     let timer: NodeJS.Timeout;
@@ -32,6 +33,16 @@ export default function AppealChatInput({
       if (timer) clearInterval(timer);
     };
   }, [isRecording]);
+
+  useEffect(() => {
+    return () => {
+      const rec = recordingRef.current;
+      if (rec) {
+        rec.stopAndUnloadAsync().catch(() => {});
+        Audio.setAudioModeAsync({ allowsRecordingIOS: false, playThroughEarpieceAndroid: false }).catch(() => {});
+      }
+    };
+  }, []);
 
   function animateIn(val: Animated.Value) {
     Animated.spring(val, { toValue: 0.9, useNativeDriver: true }).start();
@@ -58,6 +69,7 @@ export default function AppealChatInput({
       await rec.prepareToRecordAsync(Audio.RecordingOptionsPresets.HIGH_QUALITY);
       await rec.startAsync();
       setRecording(rec);
+      recordingRef.current = rec;
       setIsRecording(true);
       setRecordingTime(0);
     } catch (e) {
@@ -77,12 +89,16 @@ export default function AppealChatInput({
     } finally {
       setIsRecording(false);
       setRecording(null);
+      recordingRef.current = null;
+      await Audio.setAudioModeAsync({ allowsRecordingIOS: false, playThroughEarpieceAndroid: false });
     }
   }
 
   function cancelVoice() {
     setRecordedUri(null);
     setRecordingTime(0);
+    recordingRef.current = null;
+    void Audio.setAudioModeAsync({ allowsRecordingIOS: false, playThroughEarpieceAndroid: false });
   }
 
   async function pickFiles() {


### PR DESCRIPTION
## Summary
- ensure audio mode disables recording after stop or cancel
- clean up active recording if component unmounts mid-record

## Testing
- `npm test` *(fails: Missing script: "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68af5231f47483248b0df2ea10191b57