### PR TITLE
Use manual date formatting in MessageBubble

### DIFF
--- a/components/Appeals/MessageBubble.tsx
+++ b/components/Appeals/MessageBubble.tsx
@@ -11,8 +11,9 @@ export default function MessageBubble({ message, own }: { message: AppealMessage
     : [];
 
   const dt = new Date(message.createdAt);
-  const timeStr = new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' }).format(dt);
-  const dateStr = new Intl.DateTimeFormat(undefined, { day: '2-digit', month: '2-digit', year: '2-digit' }).format(dt);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const timeStr = `${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
+  const dateStr = `${pad(dt.getDate())}.${pad(dt.getMonth() + 1)}.${String(dt.getFullYear()).slice(-2)}`;
 
   const [sound, setSound] = useState<Audio.Sound | null>(null);
   const [playing, setPlaying] = useState(false);


### PR DESCRIPTION
## Summary
- replace Intl.DateTimeFormat with manual formatting for consistent HH:mm and dd.MM.yy display in message bubbles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit` *(fails: Cannot find module 'expo-av' or its corresponding type declarations, and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af52302bf88324ac647aec781d23f8