### PR TITLE
feat: add appeal websocket updates

### DIFF
--- a/app/(main)/services/appeals/[id].tsx
+++ b/app/(main)/services/appeals/[id].tsx
@@ -14,6 +14,7 @@ import AppealHeader from '@/components/Appeals/AppealHeader'; // <-- испра�
 import MessagesList from '@/components/Appeals/MessagesList';
 import AppealChatInput from '@/components/Appeals/AppealChatInput';
 import { AuthContext } from '@/context/AuthContext';
+import { useAppealUpdates } from '@/hooks/useAppealUpdates';
 
 export default function AppealDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -27,6 +28,9 @@ export default function AppealDetailScreen() {
   }, [appealId]);
 
   useEffect(() => { load(); }, [load]);
+
+  // Подписка на события конкретного обращения: новые сообщения, смена статуса и т.д.
+  useAppealUpdates(appealId, () => load(true));
 
   if (!data) return null;
 

--- a/app/(main)/services/appeals/index.tsx
+++ b/app/(main)/services/appeals/index.tsx
@@ -7,6 +7,7 @@ import { exportAppealsCSV } from '@/utils/appealsService';
 import { AppealPriority, AppealStatus, Scope } from '@/types/appealsTypes';
 import * as FileSystem from 'expo-file-system';
 import { OverflowMenuItem } from '@/components/ui/OverflowMenu';
+import { useAppealUpdates } from '@/hooks/useAppealUpdates';
 // import * as Sharing from 'expo-sharing';
 
 export default function AppealsIndex() {
@@ -15,6 +16,7 @@ export default function AppealsIndex() {
   const [status, setStatus] = useState<AppealStatus | undefined>();
   const [priority, setPriority] = useState<AppealPriority | undefined>();
   const [count, setCount] = useState(0);
+  const [wsTick, setWsTick] = useState(0);
   const menuItems: OverflowMenuItem[] = [
     { key: 'export', title: 'Экспорт', icon: 'download', onPress: handleExport },
     // добавляй/убирай пункты здесь
@@ -32,7 +34,13 @@ export default function AppealsIndex() {
     }
   }
 
-  const refreshKey = useMemo(() => `${scope}-${status ?? ''}-${priority ?? ''}`, [scope, status, priority]);
+  // Когда приходят события по любому обращению — обновляем список
+  useAppealUpdates(undefined, () => setWsTick((t) => t + 1));
+
+  const refreshKey = useMemo(
+    () => `${scope}-${status ?? ''}-${priority ?? ''}-${wsTick}`,
+    [scope, status, priority, wsTick],
+  );
 
   return (
     <View style={{ flex: 1, backgroundColor: '#fff', padding: 16, maxWidth: 1000 }}>

--- a/hooks/useAppealUpdates.ts
+++ b/hooks/useAppealUpdates.ts
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { API_BASE_URL } from '@/utils/config';
+import { getAccessToken } from '@/utils/tokenService';
+
+interface AppealEvent {
+  type: string;
+  [key: string]: any;
+}
+
+/**
+ * Подписка на обновления обращений через WebSocket.
+ * Если указан appealId — слушаем события конкретного обращения,
+ * иначе получаем общие события по всем обращениям.
+ */
+export function useAppealUpdates(
+  appealId: number | undefined,
+  onEvent: (event: AppealEvent) => void,
+) {
+  useEffect(() => {
+    let ws: WebSocket | null = null;
+    let isActive = true;
+
+    async function connect() {
+      const token = await getAccessToken();
+      if (!isActive) return;
+
+      const base = API_BASE_URL.replace(/^http/, 'ws');
+      const path = appealId ? `/ws/appeals/${appealId}` : '/ws/appeals';
+      const url = `${base}${path}${token ? `?token=${token}` : ''}`;
+
+      ws = new WebSocket(url);
+
+      ws.onmessage = (e) => {
+        try {
+          const payload = JSON.parse(e.data);
+          onEvent(payload);
+        } catch {
+          onEvent({ type: 'unknown' });
+        }
+      };
+
+      ws.onclose = () => {
+        if (isActive) {
+          setTimeout(connect, 5000);
+        }
+      };
+    }
+
+    connect();
+
+    return () => {
+      isActive = false;
+      if (ws) ws.close();
+    };
+  }, [appealId, onEvent]);
+}
+


### PR DESCRIPTION
## Summary
- add `useAppealUpdates` hook for subscribing to appeal changes over WebSocket
- refresh appeal list when any appeal updates are received
- auto-refresh appeal details and messages on WebSocket events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68af56768b2c83248e8c91abb51011c8