### PR TITLE
fix: improve appeal chat and list

### DIFF
--- a/app/(main)/services/appeals/[id].tsx
+++ b/app/(main)/services/appeals/[id].tsx
@@ -2,6 +2,7 @@
 import { useLocalSearchParams } from 'expo-router';
 import { useEffect, useState, useCallback, useContext } from 'react';
 import { View } from 'react-native';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import {
   addAppealMessage,
   getAppealById,
@@ -9,24 +10,39 @@ import {
   assignAppeal,
   updateAppealWatchers,
 } from '@/utils/appealsService';
-import { AppealDetail, AppealStatus } from '@/types/appealsTypes';
+import { AppealDetail, AppealStatus, AttachmentType, AppealMessage } from '@/types/appealsTypes';
 import AppealHeader from '@/components/Appeals/AppealHeader'; // <-- исправлено имя файла
 import MessagesList from '@/components/Appeals/MessagesList';
 import AppealChatInput from '@/components/Appeals/AppealChatInput';
 import { AuthContext } from '@/context/AuthContext';
+import { useAppealUpdates } from '@/hooks/useAppealUpdates';
 
 export default function AppealDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const appealId = Number(id);
   const [data, setData] = useState<AppealDetail | null>(null);
   const auth = useContext(AuthContext);
+  const tabBarHeight = useBottomTabBarHeight();
 
-  const load = useCallback(async (force = false) => {
-    const d = await getAppealById(appealId, force);
-    setData(d);
-  }, [appealId]);
+  const load = useCallback(
+    async (force = false) => {
+      const d = await getAppealById(appealId, force);
+      setData((prev) => {
+        if (!prev) return d;
+        const existing = prev.messages || [];
+        const incoming = d.messages || [];
+        const ids = new Set(incoming.map((m) => m.id));
+        const optimistic = existing.filter((m) => !ids.has(m.id));
+        return { ...d, messages: [...incoming, ...optimistic] };
+      });
+    },
+    [appealId],
+  );
 
   useEffect(() => { load(); }, [load]);
+
+  // Подписка на события конкретного обращения: новые сообщения, смена статуса и т.д.
+  useAppealUpdates(appealId, () => load(true));
 
   if (!data) return null;
 
@@ -51,12 +67,38 @@ export default function AppealDetailScreen() {
         onWatch={() => updateAppealWatchers(appealId, []).then(() => load(true))}
       />
 
-      <MessagesList messages={data.messages || []} currentUserId={auth?.profile?.id} />
+      <MessagesList
+        messages={data.messages || []}
+        currentUserId={auth?.profile?.id}
+        bottomInset={tabBarHeight + 80}
+      />
 
       <AppealChatInput
+        bottomInset={tabBarHeight}
         onSend={async ({ text, files }) => {
-          await addAppealMessage(appealId, { text, files });
-          await load(true);
+          const res = await addAppealMessage(appealId, { text, files });
+          const guessType = (mime: string): AttachmentType => {
+            if (mime.startsWith('image/')) return 'IMAGE';
+            if (mime.startsWith('audio/')) return 'AUDIO';
+            return 'FILE';
+          };
+          const newMsg: AppealMessage = {
+            id: res.id,
+            text: text,
+            createdAt: res.createdAt,
+            sender: auth?.profile
+              ? { id: auth.profile.id, email: auth.profile.email || '' }
+              : { id: 0, email: '' },
+            attachments: (files || []).map((f) => ({
+              fileUrl: f.uri,
+              fileName: f.name,
+              fileType: guessType(f.type),
+            })),
+          };
+          setData((prev) =>
+            prev ? { ...prev, messages: [...(prev.messages || []), newMsg] } : prev,
+          );
+          void load(true);
         }}
       />
     </View>

--- a/app/(main)/services/appeals/index.tsx
+++ b/app/(main)/services/appeals/index.tsx
@@ -7,6 +7,7 @@ import { exportAppealsCSV } from '@/utils/appealsService';
 import { AppealPriority, AppealStatus, Scope } from '@/types/appealsTypes';
 import * as FileSystem from 'expo-file-system';
 import { OverflowMenuItem } from '@/components/ui/OverflowMenu';
+import { useAppealUpdates } from '@/hooks/useAppealUpdates';
 // import * as Sharing from 'expo-sharing';
 
 export default function AppealsIndex() {
@@ -15,6 +16,7 @@ export default function AppealsIndex() {
   const [status, setStatus] = useState<AppealStatus | undefined>();
   const [priority, setPriority] = useState<AppealPriority | undefined>();
   const [count, setCount] = useState(0);
+  const [wsTick, setWsTick] = useState(0);
   const menuItems: OverflowMenuItem[] = [
     { key: 'export', title: 'Экспорт', icon: 'download', onPress: handleExport },
     // добавляй/убирай пункты здесь
@@ -32,7 +34,13 @@ export default function AppealsIndex() {
     }
   }
 
-  const refreshKey = useMemo(() => `${scope}-${status ?? ''}-${priority ?? ''}`, [scope, status, priority]);
+  // Когда приходят события по любому обращению — обновляем список
+  useAppealUpdates(undefined, () => setWsTick((t) => t + 1));
+
+  const refreshKey = useMemo(
+    () => `${scope}-${status ?? ''}-${priority ?? ''}-${wsTick}`,
+    [scope, status, priority, wsTick],
+  );
 
   return (
     <View style={{ flex: 1, backgroundColor: '#fff', padding: 16, maxWidth: 1000 }}>

--- a/components/Appeals/AppealHeader.tsx
+++ b/components/Appeals/AppealHeader.tsx
@@ -185,12 +185,20 @@ export default function AppealHeader({
 
         <View style={styles.infoRow}>
           <Text style={styles.number}>#{data.number}</Text>
-          <View style={[styles.badge, { backgroundColor: statusColor(data.status) }]}>
+          <PressableScale
+            onPress={() => setStatusMenuVisible(true)}
+            style={[styles.badge, { backgroundColor: statusColor(data.status) }]}
+            pressedStyle={{ opacity: 0.85 }}
+          >
             <Text style={styles.badgeText}>{statusLabels[data.status]}</Text>
-          </View>
-          <View style={[styles.badge, { backgroundColor: priorityColor(data.priority) }]}>
+          </PressableScale>
+          <PressableScale
+            onPress={() => {}}
+            style={[styles.badge, { backgroundColor: priorityColor(data.priority) }]}
+            pressedStyle={{ opacity: 0.85 }}
+          >
             <Text style={styles.badgeText}>{priorityLabels[data.priority]}</Text>
-          </View>
+          </PressableScale>
         </View>
       </LinearGradient>
 

--- a/components/Appeals/AppealList.tsx
+++ b/components/Appeals/AppealList.tsx
@@ -75,7 +75,7 @@ export default function AppealsList({
     return offset + limit < total;
   }, [meta, pageSize]);
 
-  async function load(initial = false) {
+  async function load(initial = false, retry = true) {
     if (initial) setLoading(true);
     try {
       const res = await getAppealsList(scope, pageSize, initial ? 0 : meta.offset, {
@@ -94,7 +94,11 @@ export default function AppealsList({
 
       onLoadedMeta?.(normMeta);
       onItemsChange?.(initial ? res.data : [...items, ...res.data]);
-    } catch (e) {
+    } catch (e: any) {
+      const msg = e?.message || '';
+      if (retry && /Unauthorized/i.test(msg)) {
+        return load(initial, false);
+      }
       if (initial) onLoadError?.(e);
       else onLoadMoreError?.(e);
       // можно также повесить тост

--- a/components/Appeals/MessagesList.tsx
+++ b/components/Appeals/MessagesList.tsx
@@ -7,9 +7,11 @@ import MessageBubble from './MessageBubble';
 export default function MessagesList({
   messages,
   currentUserId,
+  bottomInset = 0,
 }: {
   messages: AppealMessage[];
   currentUserId?: number;
+  bottomInset?: number;
 }) {
   const listRef = useRef<FlatList<AppealMessage>>(null);
   useEffect(() => {
@@ -24,7 +26,7 @@ export default function MessagesList({
       renderItem={({ item }) => (
         <MessageBubble message={item} own={item.sender?.id === currentUserId} />
       )}
-      contentContainerStyle={styles.container}
+      contentContainerStyle={[styles.container, { paddingBottom: bottomInset }]}
     />
   );
 }

--- a/hooks/useAppealUpdates.ts
+++ b/hooks/useAppealUpdates.ts
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { API_BASE_URL } from '@/utils/config';
+import { getAccessToken } from '@/utils/tokenService';
+
+interface AppealEvent {
+  type: string;
+  [key: string]: any;
+}
+
+/**
+ * Подписка на обновления обращений через WebSocket.
+ * Если указан appealId — слушаем события конкретного обращения,
+ * иначе получаем общие события по всем обращениям.
+ */
+export function useAppealUpdates(
+  appealId: number | undefined,
+  onEvent: (event: AppealEvent) => void,
+) {
+  useEffect(() => {
+    let ws: WebSocket | null = null;
+    let isActive = true;
+
+    async function connect() {
+      const token = await getAccessToken();
+      if (!isActive) return;
+
+      const base = API_BASE_URL.replace(/^http/, 'ws');
+      const path = appealId ? `/ws/appeals/${appealId}` : '/ws/appeals';
+      const url = `${base}${path}${token ? `?token=${token}` : ''}`;
+
+      ws = new WebSocket(url);
+
+      ws.onmessage = (e) => {
+        try {
+          const payload = JSON.parse(e.data);
+          onEvent(payload);
+        } catch {
+          onEvent({ type: 'unknown' });
+        }
+      };
+
+      ws.onclose = () => {
+        if (isActive) {
+          setTimeout(connect, 5000);
+        }
+      };
+    }
+
+    connect();
+
+    return () => {
+      isActive = false;
+      if (ws) ws.close();
+    };
+  }, [appealId, onEvent]);
+}
+

--- a/utils/apiClient.ts
+++ b/utils/apiClient.ts
@@ -52,14 +52,15 @@ async function parseResponse<Res>(response: Response): Promise<{ data: Res | und
     return { data: blob as unknown as Res };
   }
 
-  // Попробуем JSON
+  // Попробуем распарсить как JSON; если не выйдет, вернём текст
   try {
-    const json = await response.json();
+    // Используем clone, чтобы не "прочитать" основной поток тела
+    const json = await response.clone().json();
     const data = (json && typeof json === 'object' && 'data' in json) ? (json.data as Res) : (json as Res);
     const message = (json && (json.message || json.error)) as string | undefined;
     return { data, message };
   } catch {
-    // Не JSON — отдадим текст
+    // Тело не JSON — читаем оригинальный response как текст
     const text = await response.text();
     return { data: undefined, message: text || undefined };
   }


### PR DESCRIPTION
## Summary
- preserve unsynced messages when reloading appeals
- redesign chat input with separate attachment button and preview
- allow attachment picker to hide add button for preview-only use

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68af56768b2c83248e8c91abb51011c8