### PR TITLE
fix: guard chat images with missing URLs

### DIFF
--- a/components/Appeals/MessageBubble.tsx
+++ b/components/Appeals/MessageBubble.tsx
@@ -7,7 +7,10 @@ import { MotiView } from 'moti';
 
 export default function MessageBubble({ message, own }: { message: AppealMessage; own: boolean }) {
   const attachments = Array.isArray(message.attachments)
-    ? message.attachments.filter((a): a is NonNullable<typeof a> => !!a)
+    ? message.attachments.filter(
+        (a): a is NonNullable<typeof a> =>
+          !!a && (a.fileType !== 'IMAGE' || !!a.fileUrl)
+      )
     : [];
 
   const dt = new Date(message.createdAt);


### PR DESCRIPTION
## Summary
- ensure MessageBubble skips image attachments without URLs to avoid crashes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68af6392e5f48324a5281aef4d365300