### PR TITLE
fix: improve appeals chat updates

### DIFF
--- a/app/(main)/services/appeals/[id].tsx
+++ b/app/(main)/services/appeals/[id].tsx
@@ -10,7 +10,7 @@ import {
   assignAppeal,
   updateAppealWatchers,
 } from '@/utils/appealsService';
-import { AppealDetail, AppealStatus, AttachmentType, AppealMessage } from '@/types/appealsTypes';
+import { AppealDetail, AppealStatus, AppealMessage } from '@/types/appealsTypes';
 import AppealHeader from '@/components/Appeals/AppealHeader'; // <-- исправлено имя файла
 import MessagesList from '@/components/Appeals/MessagesList';
 import AppealChatInput from '@/components/Appeals/AppealChatInput';
@@ -23,6 +23,7 @@ export default function AppealDetailScreen() {
   const [data, setData] = useState<AppealDetail | null>(null);
   const auth = useContext(AuthContext);
   const tabBarHeight = useBottomTabBarHeight();
+  const [inputHeight, setInputHeight] = useState(0);
 
   const load = useCallback(async (force = false) => {
     const d = await getAppealById(appealId, force);
@@ -78,35 +79,14 @@ export default function AppealDetailScreen() {
       <MessagesList
         messages={data.messages || []}
         currentUserId={auth?.profile?.id}
-        bottomInset={tabBarHeight + 80}
+        bottomInset={inputHeight}
       />
 
       <AppealChatInput
         bottomInset={tabBarHeight}
+        onHeightChange={setInputHeight}
         onSend={async ({ text, files }) => {
-          const res = await addAppealMessage(appealId, { text, files });
-          const guessType = (mime: string): AttachmentType => {
-            if (mime.startsWith('image/')) return 'IMAGE';
-            if (mime.startsWith('audio/')) return 'AUDIO';
-            return 'FILE';
-          };
-          const newMsg: AppealMessage = {
-            id: res.id,
-            text: text,
-            createdAt: res.createdAt,
-            sender: auth?.profile
-              ? { id: auth.profile.id, email: auth.profile.email || '' }
-              : { id: 0, email: '' },
-            attachments: (files || []).map((f) => ({
-              fileUrl: f.uri,
-              fileName: f.name,
-              fileType: guessType(f.type),
-            })),
-          };
-          setData((prev) =>
-            prev ? { ...prev, messages: [...(prev.messages || []), newMsg] } : prev,
-          );
-          void load(true);
+          await addAppealMessage(appealId, { text, files });
         }}
       />
     </View>

--- a/components/Appeals/AppealChatInput.tsx
+++ b/components/Appeals/AppealChatInput.tsx
@@ -1,6 +1,6 @@
 // components/Appeals/AppealChatInput.tsx
 import React, { useState, useRef, useEffect } from 'react';
-import { View, TextInput, Pressable, StyleSheet, Text, Animated } from 'react-native';
+import { View, TextInput, Pressable, StyleSheet, Text, Animated, LayoutChangeEvent } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Audio } from 'expo-av';
 import { MotiView } from 'moti';
@@ -9,9 +9,11 @@ import AttachmentsPicker, { AttachmentFile } from '@/components/ui/AttachmentsPi
 export default function AppealChatInput({
   onSend,
   bottomInset = 0,
+  onHeightChange,
 }: {
   onSend: (payload: { text?: string; files?: AttachmentFile[] }) => Promise<void> | void;
   bottomInset?: number;
+  onHeightChange?: (h: number) => void;
 }) {
   const [text, setText] = useState('');
   const [files, setFiles] = useState<AttachmentFile[]>([]);
@@ -147,8 +149,12 @@ export default function AppealChatInput({
     if (isRecording) stopRecording();
   };
 
+  function handleLayout(e: LayoutChangeEvent) {
+    onHeightChange?.(e.nativeEvent.layout.height);
+  }
+
   return (
-    <View style={[styles.wrapper, { marginBottom: bottomInset }]}>
+    <View style={[styles.wrapper, { paddingBottom: bottomInset }]} onLayout={handleLayout}>
       <View style={styles.inputRow}>
         <AttachmentsPicker
           value={files}
@@ -207,7 +213,13 @@ export default function AppealChatInput({
 }
 
 const styles = StyleSheet.create({
-  wrapper: { padding: 8, backgroundColor: '#F9FAFB', borderTopWidth: 1, borderColor: '#E5E7EB' },
+  wrapper: {
+    padding: 8,
+    backgroundColor: '#F9FAFB',
+    borderTopWidth: 1,
+    borderColor: '#E5E7EB',
+    width: '100%',
+  },
   inputRow: { flexDirection: 'row', alignItems: 'flex-end' },
   actionBtn: {
     borderRadius: 20,

--- a/components/Appeals/MessagesList.tsx
+++ b/components/Appeals/MessagesList.tsx
@@ -1,5 +1,5 @@
 // components/Appeals/MessagesList.tsx
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useMemo } from 'react';
 import { FlatList, StyleSheet } from 'react-native';
 import { AppealMessage } from '@/types/appealsTypes';
 import MessageBubble from './MessageBubble';
@@ -14,14 +14,20 @@ export default function MessagesList({
   bottomInset?: number;
 }) {
   const listRef = useRef<FlatList<AppealMessage>>(null);
+  const uniqueMessages = useMemo(() => {
+    const map = new Map<number, AppealMessage>();
+    messages.forEach((m) => map.set(m.id, m));
+    return Array.from(map.values());
+  }, [messages]);
+
   useEffect(() => {
     listRef.current?.scrollToEnd({ animated: true });
-  }, [messages]);
+  }, [uniqueMessages]);
 
   return (
     <FlatList
       ref={listRef}
-      data={messages}
+      data={uniqueMessages}
       keyExtractor={(item) => String(item.id)}
       renderItem={({ item }) => (
         <MessageBubble message={item} own={item.sender?.id === currentUserId} />


### PR DESCRIPTION
## Summary
- rely on WebSocket events for new appeal messages
- dedupe appeal messages by id
- align chat input above tab bar and expand text field

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: Cannot find name 'RelativePathString', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68afff432ef08324ac7d6d19909b1c11