### PR TITLE
fix: refine appeals chat layout

### DIFF
--- a/components/Appeals/MessagesList.tsx
+++ b/components/Appeals/MessagesList.tsx
@@ -1,5 +1,5 @@
 // components/Appeals/MessagesList.tsx
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useMemo } from 'react';
 import { FlatList, StyleSheet } from 'react-native';
 import { AppealMessage } from '@/types/appealsTypes';
 import MessageBubble from './MessageBubble';
@@ -14,19 +14,26 @@ export default function MessagesList({
   bottomInset?: number;
 }) {
   const listRef = useRef<FlatList<AppealMessage>>(null);
+  const uniqueMessages = useMemo(() => {
+    const map = new Map<number, AppealMessage>();
+    messages.forEach((m) => map.set(m.id, m));
+    return Array.from(map.values());
+  }, [messages]);
+
   useEffect(() => {
     listRef.current?.scrollToEnd({ animated: true });
-  }, [messages]);
+  }, [uniqueMessages]);
 
   return (
     <FlatList
       ref={listRef}
-      data={messages}
+      data={uniqueMessages}
       keyExtractor={(item) => String(item.id)}
       renderItem={({ item }) => (
         <MessageBubble message={item} own={item.sender?.id === currentUserId} />
       )}
       contentContainerStyle={[styles.container, { paddingBottom: bottomInset }]}
+      style={{ flex: 1 }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- offset appeals chat by bottom bar and keyboard
- stretch message input to full width and grow up to 4 lines
- ensure message list fills space above chat input

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit` *(fails: Cannot find name 'RelativePathString', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68afff432ef08324ac7d6d19909b1c11