### PR TITLE
Fix chat input layout and date format

### DIFF
--- a/components/Appeals/AppealChatInput.tsx
+++ b/components/Appeals/AppealChatInput.tsx
@@ -177,7 +177,7 @@ export default function AppealChatInput({
           addLabel=""
           maxFiles={10}
           horizontal
-          style={{ marginRight: 8 }}
+          style={{ marginRight: 8, flexGrow: 0, flexShrink: 0 }}
         />
         {isRecording ? (
           <View style={styles.recordingBox}>
@@ -263,16 +263,17 @@ export default function AppealChatInput({
 
 const styles = StyleSheet.create({
   wrapper: {
-    padding: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
     backgroundColor: '#F9FAFB',
     borderTopWidth: 1,
     borderColor: '#E5E7EB',
     width: '100%',
   },
-  inputRow: { flexDirection: 'row', alignItems: 'flex-end' },
+  inputRow: { flexDirection: 'row', alignItems: 'center' },
   actionBtn: {
     borderRadius: 20,
-    padding: 10,
+    padding: 8,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -285,7 +286,7 @@ const styles = StyleSheet.create({
     borderColor: '#E5E7EB',
     borderRadius: 20,
     paddingHorizontal: 12,
-    paddingVertical: 8,
+    paddingVertical: 4,
     marginRight: 8,
   },
   input: {
@@ -305,7 +306,7 @@ const styles = StyleSheet.create({
     borderColor: '#E5E7EB',
     borderRadius: 20,
     paddingHorizontal: 12,
-    paddingVertical: 8,
+    paddingVertical: 4,
     marginHorizontal: 8,
   },
   wave: {
@@ -324,7 +325,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#E5E7EB',
     borderRadius: 20,
-    paddingVertical: 8,
+    paddingVertical: 4,
     paddingHorizontal: 12,
     marginHorizontal: 8,
     position: 'relative',

--- a/components/Appeals/MessageBubble.tsx
+++ b/components/Appeals/MessageBubble.tsx
@@ -14,9 +14,15 @@ export default function MessageBubble({ message, own }: { message: AppealMessage
     : [];
 
   const dt = new Date(message.createdAt);
-  const pad = (n: number) => String(n).padStart(2, '0');
-  const timeStr = `${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
-  const dateStr = `${pad(dt.getDate())}.${pad(dt.getMonth() + 1)}.${String(dt.getFullYear()).slice(-2)}`;
+  const timeStr = dt.toLocaleTimeString('ru-RU', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  const dateStr = dt.toLocaleDateString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
 
   const [sound, setSound] = useState<Audio.Sound | null>(null);
   const [playing, setPlaying] = useState(false);

--- a/components/Appeals/MessagesList.tsx
+++ b/components/Appeals/MessagesList.tsx
@@ -32,11 +32,16 @@ export default function MessagesList({
       renderItem={({ item }) => (
         <MessageBubble message={item} own={item.sender?.id === currentUserId} />
       )}
-      contentContainerStyle={[styles.container, { paddingBottom: bottomInset }]}
+      style={styles.list}
+      contentContainerStyle={[
+        styles.container,
+        { paddingBottom: bottomInset, flexGrow: 1 },
+      ]}
     />
   );
 }
 
 const styles = StyleSheet.create({
+  list: { flex: 1, width: '100%' },
   container: { paddingVertical: 8 },
 });


### PR DESCRIPTION
## Summary
- reduce chat input height and stretch message field to full width
- fix messages list scrolling by stretching FlatList
- show message timestamps in Russian format

## Testing
- `npx eslint components/Appeals/AppealChatInput.tsx components/Appeals/MessagesList.tsx components/Appeals/MessageBubble.tsx`
- `npx tsc --noEmit` *(fails: Cannot find name 'RelativePathString'; Module '"@/utils/authService"' declares 'logout' locally, but it is not exported; Property 'hovered' does not exist on type 'PressableStateCallbackType'.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba98f5225c83248a739223ab8067ff